### PR TITLE
add leaderboard cobra command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 build
 .config.*
 .vscode
+.idea/
+*.iml
+*.iws

--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -76,7 +76,7 @@ func saveIfChanged(cmd *cobra.Command, cmdString string) {
 var configureCmd = &cobra.Command{
 	Use:   "configure",
 	Short: "Configure the CLI",
-	Long:  `Set the domain, year and session token to talk to AOC`,
+	Long:  `Set the year and session token to talk to AOC`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if cmd.Flags().NFlag() == 0 {
 			term := helpers.NewInteractiveTerminal(configKeys)
@@ -85,12 +85,12 @@ var configureCmd = &cobra.Command{
 			return
 		}
 
-		saveIfChanged(cmd, "domain")
 		saveIfChanged(cmd, "year")
 		saveIfChanged(cmd, "day")
 		saveIfChanged(cmd, "session-token")
 		saveIfChanged(cmd, "root-dir")
 		saveIfChanged(cmd, "python-exec")
+		saveIfChanged(cmd, "leaderboard")
 
 		day := helpers.GetViperValueEnsureSet("day")
 		currentTime := time.Now()
@@ -108,6 +108,7 @@ var configureCmd = &cobra.Command{
 				fmt.Printf("Day in config '%s' is already set to today (%s), not changing day..\n", day, dayOfMonth)
 			}
 		}
+
 		printConfigurationTable()
 		cobra.CheckErr(viper.WriteConfig())
 	},
@@ -127,19 +128,26 @@ func parseInt(value string) int {
 func init() {
 	rootCmd.AddCommand(configureCmd)
 
-	domain := viper.GetString("domain")
+	viper.SetDefault("year", time.Now().Local().Year())
+	viper.SetDefault("day", time.Now().Local().Day())
+	viper.SetDefault("session-token", "<enter aoc token here>")
+	viper.SetDefault("root-dir", "<enter root directory for problems>")
+	viper.SetDefault("python-exec", "<enter path for python executable>")
+	viper.SetDefault("leaderboard", "<enter private leaderboard id>")
+
 	sessionToken := viper.GetString("session-token")
 	rootDir := viper.GetString("root-dir")
 	pythonExecutable := viper.GetString("python-exec")
+	leaderboard := viper.GetString("leaderboard")
 
 	year := parseInt(viper.GetString("year"))
 	day := parseInt(viper.GetString("day"))
 
-	configureCmd.Flags().StringP("domain", "d", domain, "Domain of AOC")
 	configureCmd.Flags().IntP("year", "y", year, "Selected year")
 	configureCmd.Flags().Int("day", day, "Selected day")
 	configureCmd.Flags().StringP("session-token", "t", sessionToken, "Session token copied from AOC")
 	configureCmd.Flags().StringP("root-dir", "r", rootDir, "Root directory for the problems")
 	configureCmd.Flags().StringP("python-exec", "p", pythonExecutable, "Path to the python executable")
 	configureCmd.Flags().BoolP("refresh-day", "u", false, "Simply refresh the day")
+	configureCmd.Flags().StringP("leaderboard", "l", leaderboard, "Private leaderboard id")
 }

--- a/cmd/leaderboard.go
+++ b/cmd/leaderboard.go
@@ -1,0 +1,31 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/aoccli/helpers"
+
+	"github.com/aoccli/client"
+	"github.com/spf13/cobra"
+)
+
+var leaderboardCmd = &cobra.Command{
+	Use:   "leaderboard",
+	Short: "Show current leaderboard standings",
+	Long:  "Show current leaderboard standings",
+	Run: func(cmd *cobra.Command, args []string) {
+		sessionToken := helpers.GetViperValueEnsureSet[string]("session-token")
+		leaderboardId := helpers.GetViperValueEnsureSet[string]("leaderboard")
+		aocClient, err := client.NewAOCClient(sessionToken)
+		cobra.CheckErr(err)
+
+		leaderboard, err := aocClient.GetLeaderboard(leaderboardId)
+		cobra.CheckErr(err)
+
+		fmt.Println("Current leaderboard standings:")
+		fmt.Print(leaderboard)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(leaderboardCmd)
+}

--- a/cmd/open.go
+++ b/cmd/open.go
@@ -14,9 +14,8 @@ var openCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		year := helpers.GetViperValueEnsureSet("year")
 		day := helpers.GetViperValueEnsureSet("day")
-		domain := helpers.GetViperValueEnsureSet("domain")
 
-		url := helpers.GetDayUrl(domain, year, day)
+		url := helpers.GetDayUrl("https://adventofcode.com", year, day)
 		browserCmd := exec.Command("xdg-open", url)
 		cobra.CheckErr(browserCmd.Run())
 	},

--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -16,10 +16,10 @@ var scaffoldCmd = &cobra.Command{
 		year := helpers.GetViperValueEnsureSet("year")
 		day := helpers.GetViperValueEnsureSet("day")
 
-		domain := helpers.GetViperValueEnsureSet("domain")
 		sessionToken := helpers.GetViperValueEnsureSet("session-token")
 		rootDir := helpers.GetViperValueEnsureSet("root-dir")
-		aocClient, err := client.NewAOCClient(domain, sessionToken)
+		aocClient, err := client.NewAOCClient(sessionToken)
+
 		cobra.CheckErr(err)
 
 		dayInput, err := aocClient.GetDayInput(year, day)

--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -17,11 +17,10 @@ var submitCmd = &cobra.Command{
 		year := helpers.GetViperValueEnsureSet("year")
 		day := helpers.GetViperValueEnsureSet("day")
 
-		domain := helpers.GetViperValueEnsureSet("domain")
 		sessionToken := helpers.GetViperValueEnsureSet("session-token")
 		rootDir := helpers.GetViperValueEnsureSet("root-dir")
 
-		aocClient, err := client.NewAOCClient(domain, sessionToken)
+		aocClient, err := client.NewAOCClient(sessionToken)
 		cobra.CheckErr(err)
 
 		fileClient, err := client.NewFileClient(rootDir, year, day)

--- a/helpers/urls.go
+++ b/helpers/urls.go
@@ -3,7 +3,7 @@ package helpers
 import "fmt"
 
 func GetDayUrl(domain string, year string, day string) string {
-	return fmt.Sprintf("https://%s/%s/day/%s", domain, year, day)
+	return fmt.Sprintf("%s/%d/day/%d", domain, year, day)
 }
 
 func GetDayInputUrl(domain string, year string, day string) string {
@@ -12,4 +12,8 @@ func GetDayInputUrl(domain string, year string, day string) string {
 
 func GetDaySubmitUrl(domain string, year string, day string) string {
 	return fmt.Sprintf("%s/answer", GetDayUrl(domain, year, day))
+}
+
+func GetLeaderboardUrl(domain string, leaderboardId string) string {
+	return fmt.Sprintf("%s/leaderboard/private/view/%s.json", domain, leaderboardId)
 }


### PR DESCRIPTION
- Implement leaderboard GET endpoint in AOCClient
- Set domain to `https://adventofcode.com`
- New `leaderboard` config param for private leaderboard id
- Set default values for all config parameters

Example print:
```
Current leaderboard standings:
	 1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25
1) 55	 ★  ★  ★  ★  ☆  ★  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  	 Olof Englund (11 stars)
2) 35	 ★  ★  ☆  ★  -  ★  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  	 Deladox (9 stars)
3) 28	 ★  ★  ★  ★  ☆  ★  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  	 FredrikLastow (11 stars)
4) 21	 ★  ★  ★  -  ☆  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  	 Tony Liu (7 stars)
5) 7	 ★  ★  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  	 Edwin Ekberg (4 stars)
```