### PR TITLE
Bugfix for configure command caused by year and day typing

### DIFF
--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -111,33 +111,23 @@ var configureCmd = &cobra.Command{
 	},
 }
 
-func parseInt(value string) int {
-	var err error
-	intValue := 0
-	if value != "" {
-		intValue, err = strconv.Atoi(value)
-		helpers.HandleErr(err)
-	}
-
-	return intValue
-}
 
 func init() {
 	rootCmd.AddCommand(configureCmd)
 
-	viper.SetDefault("year", time.Now().Local().Year())
-	viper.SetDefault("day", time.Now().Local().Day())
+	viper.SetDefault("year", fmt.Sprintf("%d", time.Now().Local().Year()))
+	viper.SetDefault("day", fmt.Sprintf("%02d", time.Now().Local().Day())) // Ensure it's formatted as a string
 
 	sessionToken := viper.GetString("session-token")
 	rootDir := viper.GetString("root-dir")
 	pythonExecutable := viper.GetString("python-exec")
 	leaderboard := viper.GetString("leaderboard")
 
-	year := parseInt(viper.GetString("year"))
-	day := parseInt(viper.GetString("day"))
+	year := viper.GetString("year")
+	day := viper.GetString("day")
 
-	configureCmd.Flags().IntP("year", "y", year, "Selected year")
-	configureCmd.Flags().Int("day", day, "Selected day")
+	configureCmd.Flags().StringP("year", "y", year, "Selected year")
+	configureCmd.Flags().String("day", day, "Selected day")
 	configureCmd.Flags().StringP("session-token", "t", sessionToken, "Session token copied from AOC")
 	configureCmd.Flags().StringP("root-dir", "r", rootDir, "Root directory for the problems")
 	configureCmd.Flags().StringP("python-exec", "p", pythonExecutable, "Path to the python executable")


### PR DESCRIPTION
Can be reproduced by configuring day 1 and then switching to day 2 by running `aoccli configure --day2`. The following error is then thrown 

```
Error: trying to get string value of flag of type intgoroutine 1 [running] ... 
```

Tested by running configure + scaffold + solve + submit using this str definition instead of int for year and day